### PR TITLE
Add python-telegram-bot dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 PyPDF2
 pdfkit
-
+python-telegram-bot>=20,<21


### PR DESCRIPTION
## Summary
- add python-telegram-bot>=20,<21 to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-telegram-bot<21,>=20)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fetch')*

------
https://chatgpt.com/codex/tasks/task_e_68adf3886efc832296e8949fe8897ac2