### PR TITLE
doc: ampliar documentación del bot de Telegram

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,20 +44,36 @@ Podés omitir `--forms` y usará por defecto `10-K`, `10-Q` y `8-K`.
 
 ## 🤖 Bot de Telegram
 
-El proyecto incluye un bot de Telegram para solicitar documentos desde un chat.
+El proyecto incluye un bot de Telegram para solicitar y recibir archivos PDF de filings desde un chat.  
+Cada usuario mantiene su propio estado de consulta (ticker y rango de fechas) y el bot genera el PDF utilizando las mismas funciones que el script principal.
 
-### Requisitos
+### Configuración
 
-- Conseguí un token desde [@BotFather](https://t.me/BotFather).
-- Definí la variable de entorno `TELEGRAM_BOT_TOKEN` con ese token.
-- Instalá las dependencias listadas en `requirements.txt` (incluye `python-telegram-bot`).
+1. Crea un bot con [@BotFather](https://t.me/BotFather) y obtén el token.
+2. Exporta el token en la variable de entorno `TELEGRAM_BOT_TOKEN`:
+   ```bash
+   export TELEGRAM_BOT_TOKEN="TU_TOKEN"
+   ```
+3. Instala las dependencias listadas en `requirements.txt` (incluye `python-telegram-bot`).
+4. Opcionalmente podés modificar `DEFAULT_START` en `telegram_bot.py` para cambiar la fecha inicial por defecto.
 
 ### Comandos disponibles
 
-- `/ini YYYY-MM-DD` — establece la fecha inicial. Ejemplo: `/ini 2023-01-01`.
-- `/fin YYYY-MM-DD` — establece la fecha final. Ejemplo: `/fin 2023-12-31`.
-- `/ticker TICKER` — define el ticker a consultar. Ejemplo: `/ticker AAPL`.
-- `/get` — descarga y envía el PDF de filings para el ticker configurado.
+- `/ini YYYY-MM-DD` — establece la fecha inicial. Por defecto se usa `2023-01-01`.
+- `/fin YYYY-MM-DD` — establece la fecha final. Si no se define, se usa la fecha actual.
+- `/ticker TICKER` — define el ticker a consultar (se almacena en mayúsculas).
+- `/get` — descarga los filings 10-K, 10-Q y 8-K del período y envía un único PDF.
+
+### Ejemplo de conversación
+
+```
+/ini 2023-01-01
+/fin 2023-03-31
+/ticker AAPL
+/get
+```
+
+El bot responderá enviando un archivo PDF con los documentos disponibles para el ticker en el rango de fechas indicado.
 
 ### Ejecutar el bot
 
@@ -66,6 +82,8 @@ Iniciá el servicio con:
 ```bash
 python telegram_bot.py
 ```
+
+El bot quedará escuchando mensajes y responderá a los comandos anteriores.
 
 ## 🧪 Testing automatizado
 


### PR DESCRIPTION
## Summary
- ampliar la sección del bot de Telegram con pasos de configuración, comandos y ejemplo de conversación

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'reportlab')*


------
https://chatgpt.com/codex/tasks/task_e_68adfbc0c7f88322888de101966f574d